### PR TITLE
Update API_URL for production environment

### DIFF
--- a/src/lib/server/api.ts
+++ b/src/lib/server/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 const API_URL =
   process.env.NODE_ENV === 'production'
-    ? 'https://backend.donorcom.org'
+    ? 'https://backend.donorcom.org/api'
     : 'http://localhost:8000/api'
 export const api = axios.create({
   baseURL: API_URL,

--- a/src/lib/server/protected-api.ts
+++ b/src/lib/server/protected-api.ts
@@ -4,7 +4,7 @@ import { getContext } from '@/lib/integrations/tanstack-query/root-provider'
 
 const API_URL =
   process.env.NODE_ENV === 'production'
-    ? 'https://backend.donorcom.org'
+    ? 'https://backend.donorcom.org/api'
     : 'http://localhost:8000/api'
 // Create axios instance with default config
 export const protectedApi = axios.create({


### PR DESCRIPTION
Modify the API_URL to include '/api' for the production environment in both `api.ts` and `protected-api.ts`.